### PR TITLE
patch-1.2.2

### DIFF
--- a/.github/workflows/bera-faucet-cron-job.yml
+++ b/.github/workflows/bera-faucet-cron-job.yml
@@ -9,7 +9,7 @@ jobs:
     extract-bera-token:
         runs-on: ubuntu-latest
         environment:
-            name: ${{ github.ref == 'refs/heads/main' && 'release' || 'staging' }}
+            name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/monad-faucet-cron-job.yml
+++ b/.github/workflows/monad-faucet-cron-job.yml
@@ -9,7 +9,7 @@ jobs:
     extract-monad-token:
         runs-on: ubuntu-latest
         environment:
-            name: ${{ github.ref == 'refs/heads/main' && 'release' || 'staging' }}
+            name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
 
         steps:
             - name: Checkout repository


### PR DESCRIPTION
# Rename GitHub Actions environment from 'release' to 'production'

### Overview

This PR updates the GitHub Actions workflow configuration to use the correct environment name ('production' instead of 'release') for main branch builds.

### Changes

- Modified `bera-faucet-cron-job.yml` to use 'production' environment for main branch
- Modified `monad-faucet-cron-job.yml` to use 'production' environment for main branch